### PR TITLE
Updates URL encoding/decoding to match BYOND

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,12 +1615,12 @@ dependencies = [
  "lazy_static",
  "mysql",
  "noise",
- "percent-encoding 1.0.1",
  "png",
  "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
+ "url 2.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ failure = "0.1"
 chrono = { version = "0.4", optional = true }
 crypto-hash = { version = "0.3", optional = true }
 hex = { version = "0.3", optional = true }
-percent-encoding = { version = "1.0", optional = true }
+url-dep = { version = "2.1.1", package = "url", optional = true }
 png = { version = "0.11.0", optional = true }
 git2 = { version = "0.7.1", optional = true, default-features = false }
 noise = { version = "0.6.0", optional = true}
@@ -41,7 +41,7 @@ dmi = ["png"]
 file = []
 hash = ["crypto-hash", "hex"]
 log = ["chrono"]
-url = ["percent-encoding"]
+url = ["url-dep"]
 git = ["git2", "chrono"]
 http = ["reqwest", "serde", "serde_json", "serde_derive", "lazy_static"]
 sql = ["mysql", "serde", "serde_derive", "serde_json", "lazy_static"]

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use percent_encoding::{percent_decode, utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
+use url_dep::form_urlencoded::{byte_serialize, parse};
 
 byond_fn! { url_encode(data) {
     Some(encode(data))
@@ -10,13 +10,13 @@ byond_fn! { url_decode(data) {
 } }
 
 fn encode(string: &str) -> String {
-    utf8_percent_encode(string, PATH_SEGMENT_ENCODE_SET).to_string()
+    byte_serialize(string.as_bytes()).collect()
 }
 
 fn decode(string: &str) -> Result<String> {
-    let decoded = percent_decode(string.as_bytes())
-        .decode_utf8()?
-        .into_owned();
+    let decoded: String = parse(string.as_bytes())
+        .map(|(key, val)| [key, val].concat())
+        .collect();
 
     if decoded.contains('\0') {
         return Err(Error::Null);


### PR DESCRIPTION
Rust-g currently uses percent encoding while BYOND uses form encoding. 