### PR TITLE
Updates file reading to match BYOND

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -22,6 +22,7 @@ fn read(path: &str) -> Result<String> {
 
     let mut content = String::with_capacity(metadata.len() as usize);
     file.read_to_string(&mut content)?;
+    let content = content.replace("\r\n", "\n");
 
     Ok(content)
 }


### PR DESCRIPTION
BYOND strips `\r` characters when converting a file's contents to a string. Doing so here will maintain feature parity and makes the override sensible.

---

Re-do, forgot to change the branch the first time 🤦 