### PR TITLE
Fix IconForge (3.1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "rust-g"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-g"
 edition = "2021"
-version = "3.1.0"
+version = "3.1.1"
 authors = [
     "Bjorn Neergaard <bjorn@neersighted.com>",
     "Tad Hardesty <tad@platymuus.com>",

--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -21,7 +21,7 @@
 /// list("type" = "BlendColor", "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
 /// list("type" = "BlendIcon", "icon" = [SPRITE_OBJECT], "blend_mode" = ICON_OVERLAY)
 /// list("type" = "Scale", "width" = 32, "height" = 32)
-/// list("type" = "Crop", "x1" = 0, "y1" = 0, "x2" = 32, "y2" = 32)
+/// list("type" = "Crop", "x1" = 1, "y1" = 1, "x2" = 32, "y2" = 32) // (BYOND icons index from 1,1 to the upper bound, inclusive)
 ///
 /// Returns a SpritesheetResult as JSON, containing fields:
 /// list(

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -956,7 +956,7 @@ fn transform_image(image: &mut RgbaImage, transform: &Transform) -> Result<(), S
                         image::Rgba([0, 0, 0, 0])
                     });
 
-                image::imageops::overlay(&mut blank_img, image, x_offset as i64, y_offset as i64);
+                image::imageops::replace(&mut blank_img, image, x_offset as i64, y_offset as i64);
                 *image = image::imageops::crop_imm(
                     &blank_img,
                     x1 as u32,
@@ -1055,7 +1055,12 @@ impl Rgba {
             3 => Rgba::map_each_a(
                 self,
                 other_color,
-                |c1, c2, _c1_a, c2_a| c1 + (c2 - c1) * c2_a / 255.0,
+                |c1, c2, c1_a, c2_a| {
+                    if c1_a == 0.0 {
+                        return c2;
+                    }
+                    c1 + (c2 - c1) * c2_a / 255.0
+                },
                 |a1, a2| {
                     let high = f32::max(a1, a2);
                     let low = f32::min(a1, a2);
@@ -1065,7 +1070,12 @@ impl Rgba {
             6 => Rgba::map_each_a(
                 other_color,
                 self,
-                |c1, c2, _c1_a, c2_a| c1 + (c2 - c1) * c2_a / 255.0,
+                |c1, c2, c1_a, c2_a| {
+                    if c1_a == 0.0 {
+                        return c2;
+                    }
+                    c1 + (c2 - c1) * c2_a / 255.0
+                },
                 |a1, a2| {
                     let high = f32::max(a1, a2);
                     let low = f32::min(a1, a2);


### PR DESCRIPTION
Fixes cropping from 1,1 and over-cropping, fixes overlay blending onto 0 alpha providing the wrong rgb values.
Sets version to 3.1.1