### PR TITLE
Fix subtract blending in IconForge (3.1.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "rust-g"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-g"
 edition = "2021"
-version = "3.1.2"
+version = "3.1.3"
 authors = [
     "Bjorn Neergaard <bjorn@neersighted.com>",
     "Tad Hardesty <tad@platymuus.com>",

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -1634,7 +1634,7 @@ impl Rgba {
     fn blend(&self, other_color: &Rgba, blend_mode: u8) -> Rgba {
         match blend_mode {
             0 => Rgba::map_each(self, other_color, |c1, c2| c1 + c2, f32::min),
-            1 => Rgba::map_each(self, other_color, |c1, c2| c2 - c1, f32::min),
+            1 => Rgba::map_each(self, other_color, |c1, c2| c1 - c2, f32::min),
             2 => Rgba::map_each(
                 self,
                 other_color,


### PR DESCRIPTION
This was in the upstream version of iconforge but I somehow missed it.